### PR TITLE
Add BulkUpdateFromKafkaTriggerEventsAsync to ContainerExtensions

### DIFF
--- a/templates/nostifyAggregate/_ReplaceMe_/_ReplaceMe_Aggregate.cs
+++ b/templates/nostifyAggregate/_ReplaceMe_/_ReplaceMe_Aggregate.cs
@@ -16,7 +16,7 @@ public class _ReplaceMe_ : NostifyObject, IAggregate
 
     public override void Apply(Event eventToApply)
     {
-        if (eventToApply.command == _ReplaceMe_Command.Create || eventToApply.command == _ReplaceMe_Command.Update)
+        if (eventToApply.command == _ReplaceMe_Command.BulkCreate || eventToApply.command == _ReplaceMe_Command.Create || eventToApply.command == _ReplaceMe_Command.Update)
         {
             this.UpdateProperties<_ReplaceMe_>(eventToApply.payload);
         }


### PR DESCRIPTION
BulkUpdateFromKafkaTriggerEventsAsync uses PatchItemAsync to set property values on existing documents. 