### PR TITLE
NostifyExtensions.TryGetValue - don't throw exception

### DIFF
--- a/nostify.Tests/NostifyExtensionsJObjectTests.cs
+++ b/nostify.Tests/NostifyExtensionsJObjectTests.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Newtonsoft.Json.Linq;
+using Xunit;
+using Moq;
+using nostify;
+using System.ComponentModel.DataAnnotations;
+
+public class NostifyExtensionsJObjectTests
+{
+    [Fact]
+    public void CanConvertToGuid()
+    {
+        var id = Guid.NewGuid();
+        var jObj = new JObject { { "id", id } };
+        var obj = (object)jObj;
+        var result = obj.TryGetValue<Guid>("id", out var value);
+        Assert.True(result);
+        Assert.Equal(id, value);
+    }
+
+    [Fact]
+    public void CanConvertToListGuid()
+    {
+        var id1 = Guid.NewGuid();
+        var id2 = Guid.NewGuid();
+        var jObj = new JObject { { "id", new JArray { id1, id2 } } };
+        var obj = (object)jObj;
+        var result = obj.TryGetValue<List<Guid>>("id", out var value);
+        Assert.True(result);
+        Assert.Equal(2, value.Count);
+        Assert.Equal(id1, value.First());
+        Assert.Equal(id2, value.Last());
+    }
+
+    [Fact]
+    public void TryConvertGuidToListGuidReturnsFalse()
+    {
+        var id = Guid.NewGuid();
+        var jObj = new JObject { { "id", id } };
+        var obj = (object)jObj;
+        var result = obj.TryGetValue<List<Guid>>("id", out var value);
+        Assert.False(result);
+        Assert.Null(value);
+    }
+}

--- a/src/NostifyExtensions.cs
+++ b/src/NostifyExtensions.cs
@@ -36,8 +36,16 @@ namespace nostify
             }
             else 
             {
-                value = jToken.First().ToObject<T>();
-                return true;
+                try
+                {
+                    value = jToken.First().ToObject<T>();
+                    return true;
+                }
+                catch (Exception)
+                {
+                    value = default(T);
+                    return false;
+                }
             }
         }
 


### PR DESCRIPTION
update NostifyExtensions.TryGetValue to return false instead of throwing when converting to an object of type T