### PR TITLE
Aggregate Validation

### DIFF
--- a/nostify.Tests/AggregateValidatorTests.cs
+++ b/nostify.Tests/AggregateValidatorTests.cs
@@ -1,0 +1,270 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Newtonsoft.Json.Linq;
+using Xunit;
+using Moq;
+using nostify;
+using Microsoft.Extensions.Configuration;
+
+namespace nostify.Tests;
+
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+
+public class AggregateValidatorTests
+{
+    private readonly Mock<IConfiguration> _mockConfig;
+    private readonly AggregateValidator _validator;
+
+    // Test data classes
+    private record TestAggregateDirect
+    {
+        [MaxStringLength(10)]
+        public string? Name { get; init; }
+        public string? Description { get; init; } // No attribute, should use default
+    }
+
+    private record TestAggregateConfig
+    {
+        [MaxStringLength("Validation:TestNameMaxLength")]
+        public string? Name { get; init; }
+        [MaxStringLength("Validation:MissingKey")] // Key doesn't exist, should use default
+        public string? MissingKeyField { get; init; }
+    }
+
+    private record TestAggregateDefault
+    {
+        // No attribute, should use default
+        public string? Notes { get; init; }
+    }
+
+
+    public AggregateValidatorTests()
+    {
+        _mockConfig = new Mock<IConfiguration>();
+        var configSectionStub = new Mock<IConfigurationSection>();
+
+        // Setup default config value
+        configSectionStub.Setup(x => x.Value).Returns("50"); // Default length from config
+        _mockConfig.Setup(c => c.GetSection("Nostify:Validation:DefaultMaxStringLength"))
+            .Returns(configSectionStub.Object);
+
+        // Setup specific config value for TestAggregateConfig
+        var specificConfigSectionStub = new Mock<IConfigurationSection>();
+        specificConfigSectionStub.Setup(x => x.Value).Returns("20"); // Specific length from config
+        _mockConfig.Setup(c => c.GetSection("Validation:TestNameMaxLength"))
+            .Returns(specificConfigSectionStub.Object);
+
+        // Setup mock for direct config key access used in MaxStringLengthAttribute
+        _mockConfig.Setup(c => c["Nostify:Validation:DefaultMaxStringLength"]).Returns("50");
+        _mockConfig.Setup(c => c["Validation:TestNameMaxLength"]).Returns("20");
+        //dont' setup Validation:MissingKey in order to test default fallback
+
+        _validator = new AggregateValidator(_mockConfig.Object);
+    }
+
+    [Fact]
+    public void Validate_DirectLength_Valid_ReturnsNoErrors()
+    {
+        // Arrange
+        var aggregate = new TestAggregateDirect { Name = "Valid", Description = "Short Desc" };
+
+        // Act
+        var errors = _validator.Validate(aggregate);
+
+        // Assert
+        Assert.Empty(errors);
+    }
+
+    [Fact]
+    public void Validate_DirectLength_Invalid_ReturnsError()
+    {
+        // Arrange
+        var aggregate = new TestAggregateDirect { Name = "This string is longer than 10 chars" };
+
+        // Act
+        var errors = _validator.Validate(aggregate);
+
+        // Assert
+        var error = Assert.Single(errors);
+        Assert.Equal(nameof(TestAggregateDirect.Name), error.Property);
+        Assert.Contains("exceeds max 10", error.Message);
+    }
+
+    [Fact]
+    public void Validate_DirectLength_NullString_ReturnsNoErrors()
+    {
+        // Arrange
+        var aggregate = new TestAggregateDirect { Name = null };
+
+        // Act
+        var errors = _validator.Validate(aggregate);
+
+        // Assert
+        Assert.Empty(errors);
+    }
+
+    [Fact]
+    public void Validate_DirectLength_EmptyString_ReturnsNoErrors()
+    {
+        // Arrange
+        var aggregate = new TestAggregateDirect { Name = "" };
+
+        // Act
+        var errors = _validator.Validate(aggregate);
+
+        // Assert
+        Assert.Empty(errors);
+    }
+
+
+    [Fact]
+    public void Validate_ConfigLength_Valid_ReturnsNoErrors()
+    {
+        // Arrange
+        var aggregate = new TestAggregateConfig { Name = "Valid Config Name" }; // less than 20 characters
+
+        // Act
+        var errors = _validator.Validate(aggregate);
+
+        // Assert
+        Assert.Empty(errors);
+    }
+
+    [Fact]
+    public void Validate_ConfigLength_Invalid_ReturnsError()
+    {
+        // Arrange
+        var aggregate = new TestAggregateConfig { Name = "This config name string is definitely way too long and is greater than 20 characters" };
+
+        // Act
+        var errors = _validator.Validate(aggregate);
+
+        // Assert
+        var error = Assert.Single(errors);
+        Assert.Equal(nameof(TestAggregateConfig.Name), error.Property);
+        Assert.Contains("exceeds max 20", error.Message);
+    }
+
+    [Fact]
+    public void Validate_ConfigLength_MissingKey_UsesDefault_Valid_ReturnsNoErrors()
+    {
+        // Arrange
+        // MissingKeyField uses "Validation:MissingKey", which is not configured.
+        // Should fall back to default configured length (50).
+        var aggregate = new TestAggregateConfig { MissingKeyField = "This fits within the default fifty characters" };
+
+        // Act
+        var errors = _validator.Validate(aggregate);
+
+        // Assert
+        Assert.Empty(errors);
+    }
+
+
+    [Fact]
+    public void Validate_ConfigLength_MissingKey_UsesDefault_Invalid_ReturnsError()
+    {
+        // Arrange
+        // MissingKeyField uses "Validation:MissingKey", which is not configured.
+        // Should fall back to default configured length (50).
+        var aggregate = new TestAggregateConfig { MissingKeyField = "This string is intentionally made longer than the default fifty characters limit set in the test setup" };
+
+        // Act
+        var errors = _validator.Validate(aggregate);
+
+        // Assert
+        var error = Assert.Single(errors);
+        Assert.Equal(nameof(TestAggregateConfig.MissingKeyField), error.Property);
+        Assert.Contains("exceeds max 50", error.Message);
+    }
+
+    [Fact]
+    public void Validate_DefaultLength_Valid_ReturnsNoErrors()
+    {
+        // Arrange
+        // TestAggregateDefault.Notes has no attribute, uses default configured length (50).
+        var aggregate = new TestAggregateDefault { Notes = "Fits in default length of 50" };
+
+        // Act
+        var errors = _validator.Validate(aggregate);
+
+        // Assert
+        Assert.Empty(errors);
+    }
+
+    [Fact]
+    public void Validate_DefaultLength_Invalid_ReturnsError()
+    {
+        // Arrange
+        // TestAggregateDefault.Notes has no attribute, uses default configured length (50).
+        var aggregate = new TestAggregateDefault { Notes = "This notes string is definitely going to be much longer than the default fifty characters limit we set up" };
+
+        // Act
+        var errors = _validator.Validate(aggregate);
+
+        // Assert
+        var error = Assert.Single(errors);
+        Assert.Equal(nameof(TestAggregateDefault.Notes), error.Property);
+        Assert.Contains("exceeds max 50", error.Message);
+    }
+
+    [Fact]
+    public void Validate_MultipleProperties_MixedValidity_ReturnsCorrectErrors()
+    {
+        // Arrange
+        var aggregate = new TestAggregateDirect
+        {
+            Name = "This name is too long (more than ten characters)",
+            Description = "This description is also way too long for the default limit of fifty characters set in the configuration"
+        };
+
+        // Act
+        var errors = _validator.Validate(aggregate);
+
+        // Assert
+        Assert.Equal(2, errors.Count);
+        Assert.Contains(errors, e => e.Property == nameof(TestAggregateDirect.Name) && e.Message.Contains("exceeds max 10"));
+        Assert.Contains(errors, e => e.Property == nameof(TestAggregateDirect.Description) && e.Message.Contains("exceeds max 50"));
+    }
+
+    [Fact]
+    public void Validate_NullAggregate_ThrowsArgumentNullException()
+    {
+        // Arrange
+        TestAggregateDirect aggregate = null;
+
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>(() => _validator.Validate(aggregate));
+    }
+
+    [Fact]
+    public void Validate_TypeWithoutStringProperties_ReturnsNoErrors()
+    {
+        // Arrange
+        var aggregate = new { Number = 123, Date = DateTime.UtcNow };
+
+        // Act
+        var errors = _validator.Validate(aggregate);
+
+        // Assert
+        Assert.Empty(errors);
+    }
+
+    [Fact]
+    public void Validate_TypeWithoutValidationAttributes_ReturnsNoErrors()
+    {
+        _validator.DefaultMaxStringLengthValue = int.MaxValue;
+        // Arrange
+        // This type has no MaxStringLengthAttribute; DefaultMaxStringLengthValue is set to int.MaxValue
+        var aggregate = new { SomeData = "This should pass as there's no validation configured for it implicitly or explicitly beyond the default" };
+
+        // Act
+        var errors = _validator.Validate(aggregate);
+
+        // Assert
+        Assert.Empty(errors);
+    }
+}
+
+#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member

--- a/src/Event.cs
+++ b/src/Event.cs
@@ -22,10 +22,8 @@ public class Event
     ///<param name="payload">Properties to update or the id of the Aggregate to delete.</param>
     ///<param name="userId">ID of User responsible for Event.</param>
     ///<param name="partitionKey">Tenant ID to apply Event to.</param>
-    ///<param name="validator">Validator to use to validate the event payload.</param>
-    public Event(NostifyCommand command, Guid aggregateRootId, object payload, Guid userId = default, Guid partitionKey = default, IAggregateValidator? validator = null)
+    public Event(NostifyCommand command, Guid aggregateRootId, object payload, Guid userId = default, Guid partitionKey = default)
     {
-        _validator = validator;
         SetUp(command, aggregateRootId, payload, userId, partitionKey);
     }
 
@@ -36,10 +34,8 @@ public class Event
     ///<param name="payload">Properties to update or the id of the Aggregate to delete.</param>
     ///<param name="userId">ID of User responsible for Event.</param>
     ///<param name="partitionKey">Tenant ID to apply Event to.</param>
-    ///<param name="validator">Validator to use to validate the event payload.</param>
-    public Event(NostifyCommand command, object payload, Guid userId = default, Guid partitionKey = default, IAggregateValidator? validator = null)
+    public Event(NostifyCommand command, object payload, Guid userId = default, Guid partitionKey = default)
     {
-        _validator = validator;
         Guid aggregateRootId = default;
         //Check payload is not null
         CheckPayload(payload);
@@ -64,10 +60,8 @@ public class Event
     ///<param name="payload">Properties to update or the id of the Aggregate to delete.</param>
     ///<param name="userId">ID of User responsible for Event.</param>
     ///<param name="partitionKey">Partition key to apply Event to.</param>
-    ///<param name="validator">Validator to use to validate the event payload.</param>
-    public Event(NostifyCommand command, string aggregateRootId, object payload, string userId, string partitionKey, IAggregateValidator? validator = null)
+    public Event(NostifyCommand command, string aggregateRootId, object payload, string userId, string partitionKey)
     {
-        _validator = validator;
         Guid aggGuid;
         if (!Guid.TryParse(aggregateRootId, out aggGuid)){
             throw new ArgumentException("Aggregate Root ID is not parsable to a Guid");
@@ -115,8 +109,6 @@ public class Event
     ///Empty constructor for PeristedEvent, used when querying from db
     ///</summary>
     public Event() { }
-
-    private readonly IAggregateValidator? _validator;
 
     ///<summary>
     ///Timestamp of event
@@ -188,11 +180,11 @@ public class Event
     ///Validates if the payload contains all required properties for performing a command on an aggregate of type T. Will throw a ValidationException if any required properties are missing or null.
     ///</summary>
     ///<typeparam name="T">The type of the aggregate to validate against.</typeparam>
-    public Event ValidatePayload<T>() where T : NostifyObject, IAggregate
+    public Event ValidatePayload<T>(IAggregateValidator? validator = null) where T : NostifyObject, IAggregate
     {
-        if (_validator != null)
+        if (validator != null)
         {
-            _validator.Validate<T>(JObject.FromObject(payload).ToObject<T>());
+            validator.Validate<T>(JObject.FromObject(payload).ToObject<T>());
         }
 
         if (this.command.isNew)

--- a/src/Event.cs
+++ b/src/Event.cs
@@ -184,7 +184,13 @@ public class Event
     {
         if (validator != null)
         {
-            validator.Validate<T>(JObject.FromObject(payload).ToObject<T>());
+            var validationErrors = validator.Validate<T>(JObject.FromObject(payload).ToObject<T>());
+            if (validationErrors.Count > 0)
+            {
+                // create a single validation message string of the format $"{property}: {message}" separated by newlines for each error
+                var validationMessage = string.Join("\n", validationErrors.Select(e => $"  {e.Property}: {e.Message}"));
+                throw new ValidationException($"Validation failed for {typeof(T).Name}:\n{validationMessage}");
+            }
         }
 
         if (this.command.isNew)

--- a/src/Validation/AggregateValidationAttributes.cs
+++ b/src/Validation/AggregateValidationAttributes.cs
@@ -1,0 +1,98 @@
+using System;
+using System.Reflection;
+using Microsoft.Extensions.Configuration;
+
+namespace nostify;
+
+/// <summary>
+/// A validation error record.
+/// </summary>
+/// <param name="Property">The name of the property that failed validation.</param>
+/// <param name="Message">The error message.</param>
+public record ValidationError(string Property, string Message);
+
+/// <summary>
+/// A validation rule that returns a validation error.
+/// </summary>
+/// <typeparam name="T">The type of the instance being validated.</typeparam>
+/// <param name="instance">The instance being validated.</param>
+/// <returns>The validation error, or null if the instance is valid.</returns>
+public delegate ValidationError ValidationRule<T>(T instance);
+
+/// <summary>
+/// An attribute that defines a validation rule.
+/// </summary>
+public interface IValidationAttribute
+{
+    /// <summary>
+    /// Creates a validation rule for the specified property.
+    /// </summary>
+    /// <typeparam name="T">The type of the instance being validated.</typeparam>
+    /// <param name="property">The property to validate.</param>
+    /// <param name="config">The configuration.</param>
+    /// <returns>The validation rule.</returns>
+    ValidationRule<T> CreateRule<T>(
+        PropertyInfo property,
+        IConfiguration config);
+}
+
+/// <summary>
+/// Specifies the maximum length of a string property.
+/// </summary>
+[AttributeUsage(AttributeTargets.Property, AllowMultiple = false)]
+public class MaxStringLengthAttribute : Attribute, IValidationAttribute
+{
+    /// <summary>
+    /// The maximum length of the string property.
+    /// </summary>
+    public int? Length { get; }
+    /// <summary>
+    /// The configuration key for the maximum length.
+    /// </summary>
+    public string ConfigKey { get; }
+
+    /// <summary>
+    /// Creates a new instance with the specified maximum length.
+    /// </summary>
+    /// <param name="length">The maximum length of the string property.</param>
+    public MaxStringLengthAttribute(int length) { Length = length; }
+
+    /// <summary>
+    /// Creates a new instance with the specified configuration key.
+    /// </summary>
+    /// <param name="configKey">The configuration key for the maximum length.</param>
+    public MaxStringLengthAttribute(string configKey) { ConfigKey = configKey; }
+
+    /// <inheritdoc/>
+    public ValidationRule<T> CreateRule<T>(
+        PropertyInfo property,
+        IConfiguration config)
+    {
+        int? maxLength;
+        if (Length.HasValue)
+        {
+            maxLength = Length;
+        }
+        else if (!string.IsNullOrEmpty(ConfigKey) && int.TryParse(config[ConfigKey], out var cfgLen))
+        {
+            maxLength = cfgLen;
+        }
+        else
+        {
+            return null;
+        }
+
+        return instance =>
+        {
+            var str = (string)property.GetValue(instance);
+            if (!string.IsNullOrEmpty(str) && str.Length > maxLength)
+            {
+                return new ValidationError(
+                    property.Name,
+                    $"Length {str.Length} exceeds max {maxLength}.");
+            }
+            
+            return null;
+        };
+    }
+}

--- a/src/Validation/AggregateValidator.cs
+++ b/src/Validation/AggregateValidator.cs
@@ -18,7 +18,7 @@ public interface IAggregateValidator
     /// <typeparam name="T">The type of the aggregate/projection.</typeparam>
     /// <param name="aggregate">The aggregate to validate.</param>
     /// <returns>A list of ValidationErrors.</returns>
-    IReadOnlyList<ValidationError> Validate<T>(T aggregate);
+    IReadOnlyList<ValidationError> Validate<T>(T? aggregate);
 }
 
 /// <summary>
@@ -50,9 +50,13 @@ public sealed class AggregateValidator : IAggregateValidator
     }
 
     /// <inheritdoc />
-    public IReadOnlyList<ValidationError> Validate<T>(T aggregate)
+    public IReadOnlyList<ValidationError> Validate<T>(T? aggregate)
     {
-        if (aggregate is null) throw new ArgumentNullException(nameof(aggregate));
+        if (aggregate is null)
+        {
+            // nothing to validate
+            return [];
+        }
 
         // get/build the cached array of ValidationRule<T>
         var rules = (ValidationRule<T>[])_cache.GetOrAdd(

--- a/src/Validation/AggregateValidator.cs
+++ b/src/Validation/AggregateValidator.cs
@@ -32,9 +32,9 @@ public sealed class AggregateValidator : IAggregateValidator
     public string DefaultMaxStringLengthConfigKey { get; set; } = "Nostify:Validation:DefaultMaxStringLength";
     
     /// <summary>
-    /// The default maximum string length; defaults to 100,000.
+    /// The default maximum string length; defaults to 1024
     /// </summary>
-    public int? DefaultMaxStringLengthValue { get; set; } = 100000;
+    public int? DefaultMaxStringLengthValue { get; set; } = 1024;
 
     private readonly IConfiguration _config;
     private readonly ConcurrentDictionary<Type, object> _cache = new();

--- a/src/Validation/AggregateValidator.cs
+++ b/src/Validation/AggregateValidator.cs
@@ -32,9 +32,9 @@ public sealed class AggregateValidator : IAggregateValidator
     public string DefaultMaxStringLengthConfigKey { get; set; } = "Nostify:Validation:DefaultMaxStringLength";
     
     /// <summary>
-    /// The default maximum string length; defaults to 1024.
+    /// The default maximum string length; defaults to 100,000.
     /// </summary>
-    public int? DefaultMaxStringLengthValue { get; set; } = 1024;
+    public int? DefaultMaxStringLengthValue { get; set; } = 100000;
 
     private readonly IConfiguration _config;
     private readonly ConcurrentDictionary<Type, object> _cache = new();

--- a/src/Validation/AggregateValidator.cs
+++ b/src/Validation/AggregateValidator.cs
@@ -1,0 +1,131 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Microsoft.Extensions.Configuration;
+
+namespace nostify;
+
+/// <summary>
+/// Validates an aggregate instance.
+/// </summary>
+public interface IAggregateValidator
+{
+    /// <summary>
+    /// Validates the aggregate and returns any ValidationErrors.
+    /// </summary>
+    /// <typeparam name="T">The type of the aggregate/projection.</typeparam>
+    /// <param name="aggregate">The aggregate to validate.</param>
+    /// <returns>A list of ValidationErrors.</returns>
+    IReadOnlyList<ValidationError> Validate<T>(T aggregate);
+}
+
+/// <summary>
+/// Validates aggregates by checking max string‑length attributes (or config defaults).
+/// </summary>
+public sealed class AggregateValidator : IAggregateValidator
+{
+    /// <summary>
+    /// The configuration key for the default maximum string length; defaults to "Nostify:Validation:DefaultMaxStringLength".
+    /// </summary>
+    public string DefaultMaxStringLengthConfigKey { get; set; } = "Nostify:Validation:DefaultMaxStringLength";
+    
+    /// <summary>
+    /// The default maximum string length; defaults to 1024.
+    /// </summary>
+    public int? DefaultMaxStringLengthValue { get; set; } = 1024;
+
+    private readonly IConfiguration _config;
+    private readonly ConcurrentDictionary<Type, object> _cache = new();
+
+    /// <summary>
+    /// Creates a new AggregateValidator with the specified configuration.
+    /// </summary>
+    /// <param name="config">The configuration.</param>
+    public AggregateValidator(IConfiguration config)
+    {
+        _config = config;
+        DefaultMaxStringLengthValue = config.GetValue<int?>(DefaultMaxStringLengthConfigKey, DefaultMaxStringLengthValue);
+    }
+
+    /// <inheritdoc />
+    public IReadOnlyList<ValidationError> Validate<T>(T aggregate)
+    {
+        if (aggregate is null) throw new ArgumentNullException(nameof(aggregate));
+
+        // get/build the cached array of ValidationRule<T>
+        var rules = (ValidationRule<T>[])_cache.GetOrAdd(
+            typeof(T),
+            _ => BuildRules<T>());
+
+        var errors = new List<ValidationError>();
+        foreach (var rule in rules)
+        {
+            var err = rule(aggregate);
+            if (err != null)
+            {
+                errors.Add(err);
+            }
+        }
+
+        return errors;
+    }
+
+    private ValidationRule<T>[] BuildRules<T>()
+    {
+        var rules = new List<ValidationRule<T>>();
+        var allProps = typeof(T).GetProperties(BindingFlags.Public | BindingFlags.Instance);
+        var handledProperties = new HashSet<PropertyInfo>();
+
+        // Process attributes first
+        foreach (var prop in allProps)
+        {
+            var validationAttributes = prop.GetCustomAttributes().OfType<IValidationAttribute>().ToList();
+            if (validationAttributes.Any())
+            {
+                // Mark property as handled so the global default isn't applied later
+                foreach (var attr in validationAttributes)
+                {
+                    // Pass the non-nullable fallback int to CreateRule
+                    // MaxStringLengthAttribute uses this if it doesn't define its own Length or ConfigKey
+                    var rule = attr.CreateRule<T>(prop, _config);
+                    if (rule != null)
+                    {
+                        rules.Add(rule);
+                        handledProperties.Add(prop);
+                    }
+                }
+            }
+        }
+
+        // Now process string properties *without* attributes, if the global default length is set
+        if (DefaultMaxStringLengthValue.HasValue) // Check if a global default was configured
+        {
+            var maxLength = DefaultMaxStringLengthValue.Value;
+            var stringProps = allProps
+                .Where(p => p.PropertyType == typeof(string) && !handledProperties.Contains(p));
+
+            foreach (var prop in stringProps)
+            {
+                // Create a default MaxStringLength rule for unattributed string properties
+                rules.Add(instance =>
+                {
+                    if (instance != null)
+                    {
+                        var str = prop.GetValue(instance) as string;
+                        if (!string.IsNullOrEmpty(str) && str.Length > maxLength)
+                        {
+                            return new ValidationError(
+                                prop.Name,
+                                $"Length {str.Length} exceeds max {maxLength}.");
+                        }
+                    }
+                    return null;
+                });
+            }
+        }
+
+        return rules.Where(rule => rule != null).ToArray();
+    }
+}


### PR DESCRIPTION
The AggregateValidator class is setup to validate string properties that have the MaxStringLength Attribute, or to use a default value if configured; if not configured, the default MaxStringLength is 1024 and will be used for all string properties that are not overridden by MaxStringLengthAttribute.

The default max string length can be configured in appsettings.json with "Nostify:Validation:DefaultMaxStringLength", e.g.:
```json
{
  "Nostify": {
    "Validation": {
      "DefaultMaxStringLength": 10000
    }
  }
}
```

The MaxStringLengthAttribute can be configured either directly with an int value or with a configuration key:
```cs
class Foo {
  [MaxStringLength Length=10000]
  public string Data { get; set; }

  [MaxStringLength ConfigKey="Aggregates:FooNameLength"]
  public string Name { get; set; }
}
```
```json
{
  "Aggregates": {
    "FooNameLength": 50
  }
}
```

AggregateValidator is designed to support new IValidationAttributes - for example, creating a MaxIntValueAttribute would just need to implement IValidationAttribute and AggregateValidator.Validate will pick it up when it builds the validation rules.