### PR TITLE
Add CosmosDB Retry to Durable Task and Projection Initializers

### DIFF
--- a/Specs/DurableProjectionInitializer.spec.md
+++ b/Specs/DurableProjectionInitializer.spec.md
@@ -28,7 +28,9 @@ public DurableProjectionInitializer(
     INostify nostify,
     string instanceId,
     int batchSize = 1000,
-    int concurrentBatchCount = 5)
+    int concurrentBatchCount = 5,
+    TaskOptions? durableTaskOptions = null,
+    RetryOptions? cosmosRetryOptions = null)
 ```
 
 | Parameter | Type | Default | Description |
@@ -38,6 +40,8 @@ public DurableProjectionInitializer(
 | `instanceId` | `string` | — | Durable orchestration instance ID; only one orchestration with this ID may run at a time. Falls back to `"{nameof(TProjection)}_Init"` if null |
 | `batchSize` | `int` | 1000 | Number of aggregate IDs processed per activity invocation |
 | `concurrentBatchCount` | `int` | 5 | Number of batches dispatched concurrently per page; page size = `batchSize × concurrentBatchCount` |
+| `durableTaskOptions` | `TaskOptions?` | null | Durable retry policy applied to each activity call the orchestrator makes. When null, defaults to 3 attempts / 5 s initial delay / 2× backoff |
+| `cosmosRetryOptions` | `RetryOptions?` | null | Retry policy for the individual Cosmos reads and writes performed inside activity methods. When null, default `RetryOptions` are used (3 retries, 1 s delay, 2× backoff) |
 
 ## Public Methods
 
@@ -78,7 +82,10 @@ Tenant-partitioned orchestrator body. Use this overload when the aggregate's cur
 
 1. Call `deleteActivityName` — deletes all existing projections.
 2. Call `getTenantIdsActivityName` — fetches distinct tenant IDs (`List<Guid>`) from the aggregate's current-state container.
-3. For each tenant, page through aggregate IDs (calling `getIdsActivityName` with `DurableInitPageInfo`) and fan out `processBatchActivityName` calls concurrently (up to `concurrentBatchCount` at a time), with a 3-attempt retry policy (5 s initial delay, 2× backoff).
+3. For each tenant, page through aggregate IDs (calling `getIdsActivityName` with `DurableInitPageInfo`) and fan out `processBatchActivityName` calls concurrently (up to `concurrentBatchCount` at a time).
+
+By default, each activity is made with a 3-attempt retry policy (5 s initial delay, 2× backoff).
+
 
 Pass `context.CreateReplaySafeLogger` for the `logger` argument to avoid duplicate log entries during orchestration replay.
 

--- a/nostify.Tests/DurableProjectionInitializer.Tests.cs
+++ b/nostify.Tests/DurableProjectionInitializer.Tests.cs
@@ -1574,4 +1574,175 @@ public class DurableProjectionInitializerTests
     //   - ProcessBatch:            events are fetched, applied to projections, and InitAsync is called
 
     #endregion
+
+    #region Cancellation Tests
+
+    // Report cancelled for any orchestration that is done - Completed, Failed, Terminated, Canceled
+    [Theory]
+    [InlineData(OrchestrationRuntimeStatus.Running, false)]
+    [InlineData(OrchestrationRuntimeStatus.Pending, false)]
+    [InlineData(OrchestrationRuntimeStatus.Suspended, false)]
+    [InlineData(OrchestrationRuntimeStatus.Terminated, true)]
+    [InlineData(OrchestrationRuntimeStatus.Completed, true)]
+    [InlineData(OrchestrationRuntimeStatus.Failed, true)]
+    // .Canceled is obsolete, but test it anyways
+    [InlineData(OrchestrationRuntimeStatus.Canceled, true)]
+    public async Task IsCancellationRequestedAsync_ReportsCancelledForDoneTasks(
+        OrchestrationRuntimeStatus status,
+        bool expectedCancelled)
+    {
+        var clientMock = new Mock<DurableTaskClient>("test");
+        clientMock
+            .Setup(c => c.GetInstanceAsync("test-instance", It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CreateMetadataWithStatus(status));
+
+        var initializer = CreateInitializer("test-instance");
+
+        Assert.Equal(expectedCancelled, await initializer.IsCancellationRequestedAsync(clientMock.Object));
+    }
+
+    [Fact]
+    public async Task IsCancellationRequestedAsync_WhenInstanceMissing_ReturnsTrue()
+    {
+        var clientMock = new Mock<DurableTaskClient>("test");
+        clientMock
+            .Setup(c => c.GetInstanceAsync("test-instance", It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((OrchestrationMetadata?)null);
+
+        var initializer = CreateInitializer("test-instance");
+
+        Assert.True(await initializer.IsCancellationRequestedAsync(clientMock.Object));
+    }
+
+    [Fact]
+    public async Task ProcessBatch_WhenCancelled_DoesNotReadEventStore()
+    {
+        var clientMock = new Mock<DurableTaskClient>("test");
+        clientMock
+            .Setup(c => c.GetInstanceAsync("test-instance", It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CreateMetadataWithStatus(OrchestrationRuntimeStatus.Terminated));
+
+        var initializer = CreateInitializer("test-instance");
+
+        await initializer.ProcessBatch(new List<Guid> { Guid.NewGuid() }, clientMock.Object);
+
+        _nostifyMock.Verify(n => n.GetEventStoreContainerAsync(It.IsAny<bool>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task DeleteAllProjections_WhenCancelled_DoesNotTouchProjectionContainer()
+    {
+        var clientMock = new Mock<DurableTaskClient>("test");
+        clientMock
+            .Setup(c => c.GetInstanceAsync("test-instance", It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CreateMetadataWithStatus(OrchestrationRuntimeStatus.Terminated));
+
+        var initializer = CreateInitializer("test-instance");
+
+        await initializer.DeleteAllProjections(clientMock.Object);
+
+        _nostifyMock.Verify(
+            n => n.GetBulkProjectionContainerAsync<TestProjection>(It.IsAny<string>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task CancelOrchestration_WhenPendingInstance_Terminates()
+    {
+        var clientMock = new Mock<DurableTaskClient>("test");
+        var pendingMetadata = CreateMetadataWithStatus(OrchestrationRuntimeStatus.Pending);
+        var terminatedMetadata = CreateMetadataWithStatus(OrchestrationRuntimeStatus.Terminated);
+
+        clientMock
+            .SetupSequence(c => c.GetInstanceAsync("test-instance", It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(pendingMetadata)
+            .ReturnsAsync(terminatedMetadata);
+
+        clientMock
+            .Setup(c => c.TerminateInstanceAsync("test-instance", It.IsAny<object>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        clientMock
+            .Setup(c => c.WaitForInstanceCompletionAsync("test-instance", It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(terminatedMetadata);
+
+        clientMock
+            .Setup(c => c.PurgeInstanceAsync("test-instance", It.IsAny<PurgeInstanceOptions?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new PurgeResult(1));
+
+        var initializer = CreateInitializer("test-instance");
+        var req = MockHttpRequestData.Create();
+
+        await initializer.CancelOrchestration(req, clientMock.Object);
+
+        clientMock.Verify(
+            c => c.TerminateInstanceAsync("test-instance", It.IsAny<object>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task CancelOrchestration_WhenSuspendedInstance_ResumesBeforeTerminating()
+    {
+        // Ensure that a suspended instance is resumed before termination, otherwise
+        // WaitForInstanceCompletionAsync blocks forever
+        var clientMock = new Mock<DurableTaskClient>("test");
+        var suspendedMetadata = CreateMetadataWithStatus(OrchestrationRuntimeStatus.Suspended);
+        var terminatedMetadata = CreateMetadataWithStatus(OrchestrationRuntimeStatus.Terminated);
+        var callOrder = new List<string>();
+
+        clientMock
+            .SetupSequence(c => c.GetInstanceAsync("test-instance", It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(suspendedMetadata)
+            .ReturnsAsync(terminatedMetadata);
+
+        clientMock
+            .Setup(c => c.ResumeInstanceAsync("test-instance", It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Callback(() => callOrder.Add("Resume"))
+            .Returns(Task.CompletedTask);
+
+        clientMock
+            .Setup(c => c.TerminateInstanceAsync("test-instance", It.IsAny<object>(), It.IsAny<CancellationToken>()))
+            .Callback(() => callOrder.Add("Terminate"))
+            .Returns(Task.CompletedTask);
+
+        clientMock
+            .Setup(c => c.WaitForInstanceCompletionAsync("test-instance", It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(terminatedMetadata);
+
+        clientMock
+            .Setup(c => c.PurgeInstanceAsync("test-instance", It.IsAny<PurgeInstanceOptions?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new PurgeResult(1));
+
+        var initializer = CreateInitializer("test-instance");
+        var req = MockHttpRequestData.Create();
+
+        await initializer.CancelOrchestration(req, clientMock.Object);
+
+        Assert.Equal(new[] { "Resume", "Terminate" }, callOrder);
+    }
+
+    [Fact]
+    public async Task StartOrchestration_WhenExistingInstanceIsSuspended_Returns409Conflict()
+    {
+        // Starting a new instance with the same ID returns 409 and not schedule a new one
+        var clientMock = new Mock<DurableTaskClient>("test");
+        clientMock
+            .Setup(c => c.GetInstanceAsync("test-instance", It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CreateMetadataWithStatus(OrchestrationRuntimeStatus.Suspended));
+
+        var initializer = CreateInitializer("test-instance");
+        var req = MockHttpRequestData.Create();
+
+        var response = await initializer.StartOrchestration(req, clientMock.Object, "OrchestratorName");
+
+        Assert.Equal(HttpStatusCode.Conflict, response.StatusCode);
+        clientMock.Verify(
+            c => c.ScheduleNewOrchestrationInstanceAsync(
+                It.IsAny<TaskName>(),
+                It.IsAny<StartOrchestrationOptions?>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    #endregion
 }

--- a/src/Projection/DurableProjectionInitializer.cs
+++ b/src/Projection/DurableProjectionInitializer.cs
@@ -109,7 +109,7 @@ public class DurableProjectionInitializer<TProjection, TAggregate>
         {
             if (IsInstanceActive(existing))
             {
-                // resum a suspended ochestration so that it can be terminated
+// resume a suspended orchestration so that it can be terminated
                 if (existing.RuntimeStatus == OrchestrationRuntimeStatus.Suspended)
                 {
                     await client.ResumeInstanceAsync(_instanceId, $"{_instanceId} resumed to cancel");

--- a/src/Projection/DurableProjectionInitializer.cs
+++ b/src/Projection/DurableProjectionInitializer.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Net;
 using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 
 using Microsoft.Azure.Cosmos;
@@ -32,6 +33,9 @@ public class DurableProjectionInitializer<TProjection, TAggregate>
     private readonly int _batchSize;
     private readonly int _pageSize;
 
+    private readonly TaskOptions _durableTaskOptions;
+    private readonly RetryOptions _cosmosRetryOptions;
+
     /// <summary>
     /// Initializes a new instance of the <see cref="DurableProjectionInitializer{TProjection, TAggregate}"/> class.
     /// </summary>
@@ -40,7 +44,16 @@ public class DurableProjectionInitializer<TProjection, TAggregate>
     /// <param name="instanceId">The instance Id; only one orchestration can run at a time with this Id.</param>
     /// <param name="batchSize">The number of projections to initialize in a batch.</param>
     /// <param name="concurrentBatchCount">The number of concurrent batches to process.</param>
-    public DurableProjectionInitializer(HttpClient httpClient, INostify nostify, string instanceId, int batchSize = 1000, int concurrentBatchCount = 5)
+    /// <param name="durableTaskOptions">Retry options for the orchestrator - if null, default TaskOptions are used (see <see cref="CreateDefaultTaskOptions"/>)</param>
+    /// <param name="cosmosRetryOptions">Retry options for Cosmos DB operations - if null, default RetryOptions are used</param>
+    public DurableProjectionInitializer(
+        HttpClient httpClient,
+        INostify nostify,
+        string instanceId,
+        int batchSize = 1000,
+        int concurrentBatchCount = 5,
+        TaskOptions? durableTaskOptions = null,
+        RetryOptions? cosmosRetryOptions = null)
     {
         _httpClient = httpClient;
         _nostify = nostify;
@@ -48,6 +61,9 @@ public class DurableProjectionInitializer<TProjection, TAggregate>
 
         _batchSize = batchSize;
         _pageSize = batchSize * concurrentBatchCount;
+
+        _durableTaskOptions = durableTaskOptions ?? CreateDefaultTaskOptions();
+        _cosmosRetryOptions = cosmosRetryOptions ?? new RetryOptions();
     }
 
     /// <summary>
@@ -64,8 +80,8 @@ public class DurableProjectionInitializer<TProjection, TAggregate>
     {
         var existing = await client.GetInstanceAsync(_instanceId);
 
-        // only allow one orchestration to run at a time — block if Running (IsRunning) or Pending
-        if (existing != null && (existing.IsRunning || existing.RuntimeStatus == OrchestrationRuntimeStatus.Pending))
+        // only allow one orchestration to run at a time — block if the instance is still active
+        if (IsInstanceActive(existing))
         {
             // already active, return 409 Conflict
             var conflict = req.CreateResponse(HttpStatusCode.Conflict);
@@ -78,7 +94,7 @@ public class DurableProjectionInitializer<TProjection, TAggregate>
     }
 
     /// <summary>
-    /// Cancels the durable orchestration if it is running, and purges the instance after cancellation.
+    /// Cancels the durable orchestration if it is active, and purges the instance after cancellation.
     /// </summary>
     /// <param name="req">The HTTP request data from the Azure Function.</param>
     /// <param name="client">The durable task client injected by the Azure host.</param>
@@ -91,8 +107,14 @@ public class DurableProjectionInitializer<TProjection, TAggregate>
         var existing = await client.GetInstanceAsync(_instanceId);
         if (existing != null)
         {
-            if (existing.RuntimeStatus == OrchestrationRuntimeStatus.Running)
+            if (IsInstanceActive(existing))
             {
+                // resum a suspended ochestration so that it can be terminated
+                if (existing.RuntimeStatus == OrchestrationRuntimeStatus.Suspended)
+                {
+                    await client.ResumeInstanceAsync(_instanceId, $"{_instanceId} resumed to cancel");
+                }
+
                 await client.TerminateInstanceAsync(_instanceId, $"{_instanceId} cancelled");
                 await client.WaitForInstanceCompletionAsync(_instanceId);
 
@@ -108,6 +130,24 @@ public class DurableProjectionInitializer<TProjection, TAggregate>
 
         return resp;
     }
+
+    /// <summary>
+    /// Checks if an activity should be cancelled
+    /// </summary>
+    public async Task<bool> IsCancellationRequestedAsync(DurableTaskClient client, CancellationToken cancellationToken = default)
+    {
+        var existing = await client.GetInstanceAsync(_instanceId, false, cancellationToken);
+        return !IsInstanceActive(existing);
+    }
+
+    /// <summary>
+    /// Checks if an orchestration is active
+    /// </summary>
+    private static bool IsInstanceActive(OrchestrationMetadata? metadata)
+        => metadata != null
+            && (metadata.RuntimeStatus == OrchestrationRuntimeStatus.Running
+                || metadata.RuntimeStatus == OrchestrationRuntimeStatus.Pending
+                || metadata.RuntimeStatus == OrchestrationRuntimeStatus.Suspended);
 
     /// <summary>
     /// The orchestrator that runs the projection initialization logic, paging through aggregates by tenant partition.
@@ -129,13 +169,11 @@ public class DurableProjectionInitializer<TProjection, TAggregate>
         )
     {
         // delete Projections
-        await context.CallActivityAsync(deleteActivityName);
+        await context.CallActivityAsync(deleteActivityName, null, _durableTaskOptions);
         logger?.LogInformation($"{_instanceId}: delete all projections");
 
-        var retryOptions = CreateRetryOptions();
-
         // get tenant ids to query by tenant partition
-        List<Guid> tenantIds = await context.CallActivityAsync<List<Guid>>(getTenantIdsActivityName);
+        List<Guid> tenantIds = await context.CallActivityAsync<List<Guid>>(getTenantIdsActivityName, null, _durableTaskOptions);
         logger?.LogInformation($"{_instanceId}: processing {tenantIds.Count} tenants");
 
         int totalProcessed = 0;
@@ -146,7 +184,6 @@ public class DurableProjectionInitializer<TProjection, TAggregate>
                 context,
                 getIdsActivityName,
                 processBatchActivityName,
-                retryOptions,
                 pageNum => new DurableInitPageInfo(tenantId, pageNum),
                 count =>
                 {
@@ -179,13 +216,11 @@ public class DurableProjectionInitializer<TProjection, TAggregate>
         )
     {
         // delete Projections
-        await context.CallActivityAsync(deleteActivityName);
+        await context.CallActivityAsync(deleteActivityName, null, _durableTaskOptions);
         logger?.LogInformation($"{_instanceId}: delete all projections");
 
-        var retryOptions = CreateRetryOptions();
-
         // get partition key values to page through
-        List<string> partitionKeys = await context.CallActivityAsync<List<string>>(getPartitionKeysActivityName);
+        List<string> partitionKeys = await context.CallActivityAsync<List<string>>(getPartitionKeysActivityName, null, _durableTaskOptions);
         logger?.LogInformation($"{_instanceId}: processing {partitionKeys.Count} partitions");
 
         int totalProcessed = 0;
@@ -196,7 +231,6 @@ public class DurableProjectionInitializer<TProjection, TAggregate>
                 context,
                 getIdsActivityName,
                 processBatchActivityName,
-                retryOptions,
                 pageNum => new DurablePartitionInitPageInfo(pk, pageNum),
                 count =>
                 {
@@ -209,10 +243,10 @@ public class DurableProjectionInitializer<TProjection, TAggregate>
     }
 
     /// <summary>
-    /// Builds the standard retry policy used for all process-batch activity invocations:
+    /// Builds the default orchestrator retry policy used for all activity invocations when none is supplied to the constructor:
     /// 3 attempts, 5-second initial delay, 2x exponential backoff.
     /// </summary>
-    private static TaskOptions CreateRetryOptions()
+    public static TaskOptions CreateDefaultTaskOptions()
     {
         return new TaskOptions(TaskRetryOptions.FromRetryPolicy(new RetryPolicy(
             maxNumberOfAttempts: 3,
@@ -229,14 +263,13 @@ public class DurableProjectionInitializer<TProjection, TAggregate>
         TaskOrchestrationContext context,
         string getIdsActivityName,
         string processBatchActivityName,
-        TaskOptions retryOptions,
         Func<int, TPageInfo> pageInfoFactory,
         Action<int> onPageProcessed)
     {
         int pageNum = 0;
         while (true)
         {
-            var pageIds = await context.CallActivityAsync<List<Guid>>(getIdsActivityName, pageInfoFactory(pageNum));
+            var pageIds = await context.CallActivityAsync<List<Guid>>(getIdsActivityName, pageInfoFactory(pageNum), _durableTaskOptions);
             if (pageIds.Count == 0)
             {
                 // no more ids to process
@@ -249,7 +282,7 @@ public class DurableProjectionInitializer<TProjection, TAggregate>
             // this splits the pageIds into `concurrentBatchCount` batches with at most `_batchSize` ids
             var tasks = pageIds
                 .Chunk(_batchSize)
-                .Select(batch => context.CallActivityAsync(processBatchActivityName, batch.ToList(), retryOptions))
+                .Select(batch => context.CallActivityAsync(processBatchActivityName, batch.ToList(), _durableTaskOptions))
                 .ToList();
 
             await Task.WhenAll(tasks);
@@ -266,10 +299,21 @@ public class DurableProjectionInitializer<TProjection, TAggregate>
     /// <summary>
     /// Deletes all projections of <typeparamref name="TProjection"/> from the bulk container.
     /// </summary>
-    public async Task DeleteAllProjections()
+    /// <param name="client">
+    /// Optional durable task client, used to check for cancellation.
+    /// </param>
+    public async Task DeleteAllProjections(DurableTaskClient? client = null)
     {
+        if (client != null && await IsCancellationRequestedAsync(client))
+        {
+            return;
+        }
+
         var container = await _nostify.GetBulkProjectionContainerAsync<TProjection>();
-        await container.DeleteAllBulkAsync<TProjection>();
+        List<TProjection> allProjections = await container.WithRetry(_cosmosRetryOptions)
+            .GetItemLinqQueryable<TProjection>()
+            .ReadAllAsync();
+        await container.BulkDeleteAsync(allProjections, _cosmosRetryOptions);
     }
 
     /// <summary>
@@ -278,7 +322,8 @@ public class DurableProjectionInitializer<TProjection, TAggregate>
     public async Task<List<Guid>> GetDistinctTenantIds()
     {
         var container = await _nostify.GetCurrentStateContainerAsync<TAggregate>();
-        return await container.GetItemLinqQueryable<TAggregate>()
+        return await container.WithRetry(_cosmosRetryOptions)
+            .GetItemLinqQueryable<TAggregate>()
             .Select(x => x.tenantId)
             .Distinct()
             .ReadAllAsync();
@@ -295,7 +340,8 @@ public class DurableProjectionInitializer<TProjection, TAggregate>
     public async Task<List<string>> GetDistinctPartitionKeys<TKey>(Expression<Func<TAggregate, TKey>> partitionKeySelector)
     {
         var container = await _nostify.GetCurrentStateContainerAsync<TAggregate>();
-        var values = await container.GetItemLinqQueryable<TAggregate>()
+        var values = await container.WithRetry(_cosmosRetryOptions)
+            .GetItemLinqQueryable<TAggregate>()
             .Select(partitionKeySelector)
             .Distinct()
             .ReadAllAsync();
@@ -326,7 +372,8 @@ public class DurableProjectionInitializer<TProjection, TAggregate>
     {
         var container = await _nostify.GetCurrentStateContainerAsync<TAggregate>();
 
-        return await container.FilteredQuery<TAggregate>(partitionKey)
+        return await container.WithRetry(_cosmosRetryOptions)
+            .FilteredQuery<TAggregate>(partitionKey)
             .Where(x => !x.isDeleted)
             .OrderBy(x => x.id)
             .Skip(pageNumber * _pageSize)
@@ -339,11 +386,20 @@ public class DurableProjectionInitializer<TProjection, TAggregate>
     /// Replays events for a batch of aggregate Ids and initializes their projections.
     /// </summary>
     /// <param name="ids">Aggregate Ids to process.</param>
-    public async Task ProcessBatch(List<Guid> ids)
+    /// <param name="client">
+    /// Optional durable task client, used to check for cancellation.
+    /// </param>
+    public async Task ProcessBatch(List<Guid> ids, DurableTaskClient? client = null)
     {
+        if (client != null && await IsCancellationRequestedAsync(client))
+        {
+            return;
+        }
+
         // get events from event store
         var eventStore = await _nostify.GetEventStoreContainerAsync();
-        var events = await eventStore.GetItemLinqQueryable<Event>()
+        var events = await eventStore.WithRetry(_cosmosRetryOptions)
+            .GetItemLinqQueryable<Event>()
             .Where(x => ids.Contains(x.aggregateRootId))
             .ReadAllAsync();
 
@@ -355,8 +411,14 @@ public class DurableProjectionInitializer<TProjection, TAggregate>
             return p;
         }).ToList();
 
+        // check for cancellation again right before InitAsync - last chance to cancel before processing this batch
+        if (client != null && await IsCancellationRequestedAsync(client))
+        {
+            return;
+        }
+
         // initialize projections
-        await _nostify.ProjectionInitializer.InitAsync(projections, _nostify, _httpClient);
+        await _nostify.ProjectionInitializer.InitAsync(projections, _nostify, _httpClient, null, _cosmosRetryOptions);
     }
 }
 

--- a/src/Projection/IProjectionInitializer.cs
+++ b/src/Projection/IProjectionInitializer.cs
@@ -27,8 +27,9 @@ public interface IProjectionInitializer
 
     /// <summary>
     /// Initializes a list of projections asynchronously. Will requery all needed data from all external services, set <c>initialized = true</c>, and update the projection container.
+    /// The bulk upsert retries individual writes on 429 TooManyRequests according to <paramref name="retryOptions"/>.
     /// </summary>
-    Task<List<P>> InitAsync<P>(List<P> projectionsToInit, INostify nostify, HttpClient? httpClient = null, DateTime? pointInTime = null)
+    Task<List<P>> InitAsync<P>(List<P> projectionsToInit, INostify nostify, HttpClient? httpClient = null, DateTime? pointInTime = null, RetryOptions? retryOptions = null)
         where P : NostifyObject, IProjection, IHasExternalData<P>, new();
 
     /// <summary>

--- a/src/Projection/ProjectionInitializer.cs
+++ b/src/Projection/ProjectionInitializer.cs
@@ -51,8 +51,9 @@ public class ProjectionInitializer : IProjectionInitializer
     /// <param name="nostify">Reference to the Nostify singleton.</param>
     /// <param name="httpClient">Optional HttpClient instance for making HTTP requests.</param>
     /// <param name="pointInTime">Point in time to query external data up to. If null, queries current state.</param>
+    /// <param name="retryOptions">Retry options for CosmosDB. Defaults to default <see cref="RetryOptions"/> when null.</param>
     /// <returns>A task that represents the asynchronous operation. The task result contains a list of initialized projections of type T.</returns>
-    public async Task<List<P>> InitAsync<P>(List<P> projectionsToInit, INostify nostify, HttpClient? httpClient = null, DateTime? pointInTime = null) where P : NostifyObject, IProjection, IHasExternalData<P>, new()
+    public async Task<List<P>> InitAsync<P>(List<P> projectionsToInit, INostify nostify, HttpClient? httpClient = null, DateTime? pointInTime = null, RetryOptions? retryOptions = null) where P : NostifyObject, IProjection, IHasExternalData<P>, new()
     {
         Container projectionContainer = await nostify.GetBulkProjectionContainerAsync<P>();
 
@@ -72,7 +73,7 @@ public class ProjectionInitializer : IProjectionInitializer
         });
 
         //Bulk upsert all projections
-        await projectionContainer.DoBulkUpsertAsync<P>(initializedProjections);
+        await projectionContainer.WithRetry(retryOptions ?? new RetryOptions()).DoBulkUpsertAsync<P>(initializedProjections);
         return initializedProjections;
     }
 

--- a/templates/nostifyProjection/_ProjectionName_/Admin/_ProjectionName_DurableInit.cs
+++ b/templates/nostifyProjection/_ProjectionName_/Admin/_ProjectionName_DurableInit.cs
@@ -62,9 +62,10 @@ public class _ProjectionName_DurableInit
 
     [Function(nameof(DeleteAll_ProjectionName_))]
     public async Task DeleteAll_ProjectionName_(
-        [ActivityTrigger] TaskActivityContext context)
+        [ActivityTrigger] TaskActivityContext context,
+        [DurableClient] DurableTaskClient client)
     {
-        await _initializer.DeleteAllProjections();
+        await _initializer.DeleteAllProjections(client);
     }
 
     [Function(nameof(GetDistinctTenantIds__ProjectionName_))]
@@ -83,8 +84,9 @@ public class _ProjectionName_DurableInit
 
     [Function(nameof(Process_ProjectionName_Batch))]
     public async Task Process_ProjectionName_Batch(
-        [ActivityTrigger] List<Guid> ids)
+        [ActivityTrigger] List<Guid> ids,
+        [DurableClient] DurableTaskClient client)
     {
-        await _initializer.ProcessBatch(ids);
+        await _initializer.ProcessBatch(ids, client);
     }
 }


### PR DESCRIPTION
* Use RetryOptions to both DurableProjectionInitializer constructor and ProjectionInitializer.InitAsync, defaulting both arguments to null. If the argument is null then default RetryOptions are used.

* DurableProjectionInitializer has both a `TaskOptions? durableTaskOptions` argument for durable task retries, for example if a timeout occurs during processing, and a `RetryOptions? cosmosRetryOptions` argument for CosmosDB retries, for example if `429 Too Many Requests` occurs during processing.

Closes #180 
